### PR TITLE
Add arm64-windows to the baseline as a CI exception for azure-identity.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -31,6 +31,7 @@
 # Add new items alphabetically
 # Cross compiling CI machine cannot run gen_test_char to generate apr_escape_test_char.h
 apr:arm64-windows=fail
+azure-identity-cpp:arm64-windows=fail
 # Requires ATL for ARM64 to be installed in CI
 azure-storage-cpp:arm64-windows=fail
 


### PR DESCRIPTION
We currently don't have support for arm64 in the azure-sdk-for-cpp CI pipelines, so setting up an exception until the underlying issue has been fixed and tested.

This change puts a stop-gap for the CI issue from https://github.com/microsoft/vcpkg/pull/15635
https://dev.azure.com/vcpkg/public/_build/results?buildId=47692&view=logs&j=36cc18b5-b00b-5122-dfd2-906b0f3945db&t=f82c2c5b-e8bf-589d-c85c-f9f694a6a0be&l=3255
```text
2021-01-14T01:32:40.1469765Z CMake Error at scripts/cmake/vcpkg_execute_build_process.cmake:145 (message):
2021-01-14T01:32:40.1475134Z     Command failed: D:/downloads/tools/cmake-3.19.2-windows/cmake-3.19.2-win32-x86/bin/cmake.exe --build . --config Debug --target install -- -v -j17
2021-01-14T01:32:40.1480240Z     Working Directory: D:/buildtrees/azure-identity-cpp/arm64-windows-dbg
2021-01-14T01:32:40.1485403Z     See logs for more information:
2021-01-14T01:32:40.1490457Z       D:\buildtrees\azure-identity-cpp\install-arm64-windows-dbg-out.log
2021-01-14T01:32:40.1492783Z 
2021-01-14T01:32:40.1497982Z Call Stack (most recent call first):
2021-01-14T01:32:40.1503229Z   scripts/cmake/vcpkg_build_cmake.cmake:96 (vcpkg_execute_build_process)
2021-01-14T01:32:40.1508378Z   scripts/cmake/vcpkg_install_cmake.cmake:27 (vcpkg_build_cmake)
2021-01-14T01:32:40.1513539Z   ports/azure-identity-cpp/portfile.cmake:20 (vcpkg_install_cmake)
2021-01-14T01:32:40.1518720Z   scripts/ports.cmake:136 (include)
2021-01-14T01:32:40.1521100Z 
2021-01-14T01:32:40.1523682Z 
2021-01-14T01:32:40.1529095Z Error: Building package azure-identity-cpp:arm64-windows failed with: BUILD_FAILED
```

The underlying cause seems to be related to a linker issue in `client_secret_credential` due to `DateTime` and the private static `SystemClockEpoch`:
```text
Creating library azure-identity.lib and object azure-identity.exp
client_secret_credential.cpp.obj : error LNK2001: unresolved external symbol "private: static class Azure::Core::DateTime const Azure::Core::DateTime::SystemClockEpoch" (?SystemClockEpoch@DateTime@Core@Azure@@0V123@B)
azure-identity.dll : fatal error LNK1120: 1 unresolved externals
```
https://github.com/Azure/azure-sdk-for-cpp/blob/af097c8e65d792387e61aca4a069efe47b6d71e5/sdk/core/azure-core/inc/azure/core/datetime.hpp#L50-L51

cc @antkmsft, @danieljurek, @vhvb1989, @RickWinter